### PR TITLE
trigger CI on forked repos

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,6 @@ name: Assignment Validation
 
 on:
   push:
-    branches:
-      - 'main'
-
   pull_request:
 
 jobs:


### PR DESCRIPTION
Since August 2021 github requires approval to run first contributors CI, and you need to reallow it at every push on the PR.
With this commit, the CI is run on the forked repo so their authors are notified of failures and you don't need to approve many times